### PR TITLE
bump to semantic versioning

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Sparkpad
-version=0.0.2
+version=0.1.0
 author=Patrick Thomas <patrick.thomas@bath.edu>	
 maintainer=Patrick Thomas <patrick.thomas@bath.edu>
 sentence=Arduino firmware for the Sparkpad


### PR DESCRIPTION
Bumped the Library file to coincide with Semantic Versioning. Theoretically it should be 1.0.0 but there are other things to be working on that could cause backwards incompatibility.